### PR TITLE
Add f.el to the package dependencies

### DIFF
--- a/current-buffer.el
+++ b/current-buffer.el
@@ -8,7 +8,7 @@
 ;; URL: https://github.com/lafrenierejm/current-buffer.el
 ;; Version: 0.1.0
 ;; Keywords: convenience
-;; Package-Requires: ((emacs "28.1"))
+;; Package-Requires: ((emacs "28.1") (f "0.20.0"))
 
 ;; This program is free software; you can redistribute it and/or modify it under
 ;; the terms of the GNU General Public License as published by the Free Software
@@ -36,6 +36,7 @@
 (require 'project)
 (require 'vc)
 (require 'vc-hooks)
+(require 'f)
 
 (defun current-buffer--obj-to-buffer (&optional buffer)
   "Get the BUFFER to use.


### PR DESCRIPTION
This also fixes the following byte-compile warnings

```
In end of data:
current-buffer.el:238:32: Warning: the function ‘f-relative’ is not known to
    be defined.
current-buffer.el:99:13: Warning: the function ‘f-parent’ is not known to be
    defined.
```